### PR TITLE
機能追加(jira.go): ADF形式のサポートとJira API v3への移行

### DIFF
--- a/domain/infra/jira.go
+++ b/domain/infra/jira.go
@@ -2,10 +2,78 @@ package infra
 
 import (
 	"fmt"
+	"net/url"
 	"os"
+	"strings"
 
 	"github.com/andygrunwald/go-jira"
 )
+
+// ADF (Atlassian Document Format) 構造体
+type ADFContent struct {
+	Type    string `json:"type"`
+	Version int    `json:"version,omitempty"`
+	Content []struct {
+		Type    string `json:"type"`
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text,omitempty"`
+		} `json:"content,omitempty"`
+	} `json:"content,omitempty"`
+}
+
+// ADFからプレーンテキストを抽出する関数
+func extractTextFromADF(adf ADFContent) string {
+	var texts []string
+	for _, content := range adf.Content {
+		for _, innerContent := range content.Content {
+			if innerContent.Text != "" {
+				texts = append(texts, innerContent.Text)
+			}
+		}
+	}
+	return strings.Join(texts, " ")
+}
+
+// Jira API v3と互換性のあるカスタムIssue構造体
+type Issue struct {
+	ID     string `json:"id"`
+	Key    string `json:"key"`
+	Fields struct {
+		Summary     string     `json:"summary"`
+		Description ADFContent `json:"description"`
+		Comment     struct {
+			Comments []struct {
+				Body    ADFContent `json:"body"`
+				Created string     `json:"created"`
+				Author  struct {
+					DisplayName string `json:"displayName"`
+				} `json:"author"`
+			} `json:"comments"`
+			MaxResults int `json:"maxResults"`
+			StartAt    int `json:"startAt"`
+			Total      int `json:"total"`
+		} `json:"comment"`
+	} `json:"fields"`
+}
+
+// プレーンテキストとしてDescriptionを取得
+func (i *Issue) GetDescription() string {
+	return extractTextFromADF(i.Fields.Description)
+}
+
+// プレーンテキストとしてコメントを取得
+func (i *Issue) GetComments() []string {
+	var comments []string
+	for _, comment := range i.Fields.Comment.Comments {
+		commentText := extractTextFromADF(comment.Body)
+		if commentText != "" {
+			comments = append(comments, fmt.Sprintf("作成者: %s\n作成日時: %s\n内容: %s",
+				comment.Author.DisplayName, comment.Created, commentText))
+		}
+	}
+	return comments
+}
 
 type Jira struct {
 	client *jira.Client
@@ -26,24 +94,40 @@ func NewJira() (*Jira, error) {
 	}, nil
 }
 
-func (h *Jira) FetchIssues(query string) ([]jira.Issue, error) {
-	issues, _, err := h.client.Issue.Search(query, &jira.SearchOptions{
-		Fields: []string{
-			"summary",
-			"description",
-			"comment",
-		},
-		MaxResults: 30,
-	})
+func (h *Jira) FetchIssues(query string) ([]Issue, error) {
+	// 新しいv3 APIエンドポイントを使用
+	params := url.Values{}
+	params.Add("jql", query)
+	params.Add("fields", "summary,description,comment")
+	params.Add("maxResults", "30")
+
+	req, err := h.client.NewRequest("GET", "rest/api/3/search/jql", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// クエリパラメーターを設定
+	req.URL.RawQuery = params.Encode()
+
+	// Jira API v3のレスポンス構造に基づいた構造体を定義
+	type SearchResult struct {
+		Issues []Issue `json:"issues"`
+		IsLast bool    `json:"isLast"`
+		Total  int     `json:"total,omitempty"`
+	}
+
+	var result SearchResult
+	_, err = h.client.Do(req, &result)
 	if err != nil {
 		return nil, fmt.Errorf("failed to search Jira API: %w", err)
 	}
 
-	if len(issues) == 0 {
-		return nil, fmt.Errorf("no issues found for query: %s", query)
+	// 空の結果は正常なケースとして扱う（エラーにしない）
+	if len(result.Issues) == 0 {
+		return []Issue{}, nil
 	}
 
-	return issues, nil
+	return result.Issues, nil
 }
 
 func (h *Jira) FetchUser(email string) (*jira.User, error) {

--- a/domain/infra/openai.go
+++ b/domain/infra/openai.go
@@ -114,7 +114,6 @@ func (h *OpenAI) GenerateJiraQuery(query string, lastError error) (string, error
 
 要件:
 - 関連性の高い課題を効率的に検索できること
-- エラーコード（G00000000形式）は重要なキーワードとして扱う
 - 2-4個の適切なキーワードを組み合わせる
 - 結果はjson形式でsearch_queryフィールドに出力
 

--- a/domain/service/select_top_issue.go
+++ b/domain/service/select_top_issue.go
@@ -5,10 +5,12 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
+	"time"
 
-	"github.com/andygrunwald/go-jira"
 	"github.com/pyama86/jipcy/domain/infra"
 	"github.com/pyama86/jipcy/domain/model"
+	"github.com/songmu/retry"
 )
 
 type SelectTopIssueService struct {
@@ -25,68 +27,135 @@ func NewSelectTopIssueService(openAI *infra.OpenAI, slack *infra.Slack, jira *in
 	}
 }
 
-func formatIssue(issue jira.Issue) string {
-	var comments []string
-	if issue.Fields.Comments != nil {
-		for _, comment := range issue.Fields.Comments.Comments {
-			// メンション防止のため包括的な変換を適用
-			authorName := strings.ReplaceAll(comment.Author.DisplayName, "@", "＠")
-			comments = append(comments, fmt.Sprintf(`
-### 作成日時:%s
-- 作成者:%s
-- 内容:%s`, comment.Created, authorName, comment.Body))
-		}
+func formatIssue(issue infra.Issue) string {
+	// 新しいADF対応メソッドを使用してコメントを取得
+	issueComments := issue.GetComments()
+	var formattedComments []string
+
+	for _, comment := range issueComments {
+		// メンション防止のため包括的な変換を適用
+		safeComment := strings.ReplaceAll(comment, "@", "＠")
+		formattedComments = append(formattedComments, fmt.Sprintf("### %s", safeComment))
 	}
+
 	return fmt.Sprintf(`## 概要
 %s
 ## 詳細
 %s
 ## コメントの履歴
-%s`, issue.Fields.Summary, issue.Fields.Description, strings.Join(comments, "\n"))
+%s`, issue.Fields.Summary, issue.GetDescription(), strings.Join(formattedComments, "\n\n"))
 }
 
-// Jiraの問い合わせから最も類似している3件を選択する関数
-func (s *SelectTopIssueService) SelectTopIssues(query string, issues []jira.Issue, channelID string) ([]model.Result, error) {
+// Jiraの問い合わせから最も類似している3件を選択する関数（並列化版）
+func (s *SelectTopIssueService) SelectTopIssues(query string, issues []infra.Issue, channelID string) ([]model.Result, error) {
+	if len(issues) == 0 {
+		return []model.Result{}, nil
+	}
+
 	jiraendpoint := strings.TrimSuffix(os.Getenv("JIRA_ENDPOINT"), "/")
-	convIssues := []model.Result{}
-
 	workspaceURL := os.Getenv("SLACK_WORKSPACE_URL")
-	for i := range issues {
-		contentSummary := formatIssue(issues[i])
-		jiraURL := fmt.Sprintf("%s/browse/%s", jiraendpoint, issues[i].Key)
 
-		threads, err := s.slack.SearchThreads(jiraURL, channelID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to search threads: %w", err)
-		}
-		slackThreadMessages, err := s.slack.FormattedSearchThreads(threads)
-		if err != nil {
-			return nil, fmt.Errorf("failed to search threads: %w", err)
-		}
+	// 結果を格納するためのチャンネル
+	type processResult struct {
+		result model.Result
+		index  int
+		err    error
+	}
 
-		similarity, err := s.openAI.CalculateSimilarity(query, contentSummary, slackThreadMessages)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get similarity: %w", err)
-		}
+	resultCh := make(chan processResult, len(issues))
+	var wg sync.WaitGroup
 
-		// 類似度が0.3以下のものは削除
-		if similarity < 0.3 {
+	// 各issueを並列で処理
+	for i, issue := range issues {
+		wg.Add(1)
+		go func(idx int, iss infra.Issue) {
+			defer wg.Done()
+
+			// リトライ機能付きで処理
+			var result model.Result
+			var processingErr error
+
+			retryErr := retry.Retry(3, 1*time.Second, func() error {
+				contentSummary := formatIssue(iss)
+				jiraURL := fmt.Sprintf("%s/browse/%s", jiraendpoint, iss.Key)
+
+				// Slack検索
+				threads, err := s.slack.SearchThreads(jiraURL, channelID)
+				if err != nil {
+					return fmt.Errorf("failed to search threads: %w", err)
+				}
+
+				slackThreadMessages, err := s.slack.FormattedSearchThreads(threads)
+				if err != nil {
+					return fmt.Errorf("failed to format threads: %w", err)
+				}
+
+				// OpenAI類似度計算（最もエラーが起きやすい部分）
+				similarity, err := s.openAI.CalculateSimilarity(query, contentSummary, slackThreadMessages)
+				if err != nil {
+					return fmt.Errorf("failed to calculate similarity: %w", err)
+				}
+
+				// 類似度が0.3以下のものは除外
+				if similarity < 0.3 {
+					result = model.Result{} // 空の結果
+					return nil
+				}
+
+				// 結果を構築
+				result = model.Result{
+					ID:             iss.ID,
+					Summary:        iss.Fields.Summary,
+					Description:    iss.GetDescription(),
+					URL:            jiraURL,
+					ContentSummary: contentSummary,
+					Similarity:     similarity,
+					SlackThread:    slackThreadMessages,
+				}
+
+				if len(threads) > 0 {
+					result.SlackThreadURL = fmt.Sprintf("%s/archives/%s/p%s", workspaceURL, threads[0].ChannelID, threads[0].Timestamp)
+				}
+
+				return nil
+			})
+
+			if retryErr != nil {
+				processingErr = retryErr
+			}
+
+			// 結果をチャンネルに送信
+			resultCh <- processResult{
+				result: result,
+				index:  idx,
+				err:    processingErr,
+			}
+		}(i, issue)
+	}
+
+	// 全てのgoroutineの完了を待つ
+	wg.Wait()
+	close(resultCh)
+
+	// 結果を収集
+	var convIssues []model.Result
+	var errors []error
+
+	for res := range resultCh {
+		if res.err != nil {
+			errors = append(errors, fmt.Errorf("issue index %d: %w", res.index, res.err))
 			continue
 		}
 
-		r := model.Result{
-			ID:             issues[i].ID,
-			Summary:        issues[i].Fields.Summary,
-			Description:    issues[i].Fields.Description,
-			URL:            jiraURL,
-			ContentSummary: contentSummary,
-			Similarity:     similarity,
-			SlackThread:    slackThreadMessages,
+		// 空の結果（類似度0.3以下）はスキップ
+		if res.result.ID != "" {
+			convIssues = append(convIssues, res.result)
 		}
-		if len(threads) > 0 {
-			r.SlackThreadURL = fmt.Sprintf("%s/archives/%s/p%s", workspaceURL, threads[0].ChannelID, threads[0].Timestamp)
-		}
-		convIssues = append(convIssues, r)
+	}
+
+	// 一部のエラーは許容するが、全てエラーの場合は失敗とする
+	if len(errors) > 0 && len(convIssues) == 0 {
+		return nil, fmt.Errorf("all issues failed to process: %v", errors)
 	}
 
 	// 類似度でソート
@@ -94,7 +163,7 @@ func (s *SelectTopIssueService) SelectTopIssues(query string, issues []jira.Issu
 		return convIssues[i].Similarity > convIssues[j].Similarity
 	})
 
-	// 最も関連度が高い3件を選択
+	// 最も関連度が高い5件を選択
 	if len(convIssues) < 5 {
 		return convIssues, nil
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/pyama86/jipcy
 go 1.23.4
 
 require (
-	github.com/andygrunwald/go-jira v1.16.0
+	github.com/andygrunwald/go-jira v1.17.0
 	github.com/jellydator/ttlcache/v3 v3.3.0
 	github.com/joho/godotenv v1.5.1
 	github.com/openai/openai-go v0.1.0-alpha.59
@@ -15,7 +15,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.14.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
-	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mx
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/andygrunwald/go-jira v1.16.0 h1:PU7C7Fkk5L96JvPc6vDVIrd99vdPnYudHu4ju2c2ikQ=
 github.com/andygrunwald/go-jira v1.16.0/go.mod h1:UQH4IBVxIYWbgagc0LF/k9FRs9xjIiQ8hIcC6HfLwFU=
+github.com/andygrunwald/go-jira v1.17.0 h1:bbu5H676l6MaNcV6A7VDIAjIOQVgzNGEhNAwNI/Cjgo=
+github.com/andygrunwald/go-jira v1.17.0/go.mod h1:tiZsPUu9824bwcI2BUXatE4hJbs9rUOif0nv1lkq1hQ=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
@@ -16,6 +18,8 @@ github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
 github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/andygrunwald/go-jira"
 	"github.com/pyama86/jipcy/domain/infra"
 	"github.com/pyama86/jipcy/domain/service"
 	"github.com/slack-go/slack"
@@ -160,7 +159,7 @@ func (h *Handler) handleMention(event *slackevents.AppMentionEvent) {
 			return
 		}
 	}
-	var issues []jira.Issue
+	var issues []infra.Issue
 	// 2. Jira検索クエリの生成
 	err := retry.Retry(5, 1*time.Second, func() error {
 		jiraQuery, err := h.openAI.GenerateJiraQuery(messageText, lastError)


### PR DESCRIPTION
- ADF形式からプレーンテキストを抽出する機能を追加
- Jira API v3に対応したカスタムIssue構造体を導入
- 並列処理とリトライ機能を用いて、Jiraの問い合わせから最も類似している5件を選択する機能を強化
- go-jiraライブラリをv1.17.0にアップデートし、JWTライブラリをv4.5.2に更新